### PR TITLE
Add Projects section with API data

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import Skills from '@/components/Skills'
 import Certificates from '@/components/Certificates'
 import TrainingCourses from '@/components/TrainingCourses'
 import Contests from '@/components/Contests'
+import Projects from '@/components/Projects'
 
 export default function Home() {
   useEffect(() => {
@@ -29,6 +30,7 @@ export default function Home() {
       <Certificates />
       <TrainingCourses />
       <Contests />
+      <Projects />
 
     </div>
   )

--- a/src/components/Certificates.tsx
+++ b/src/components/Certificates.tsx
@@ -37,7 +37,7 @@ export default function Certificates() {
             <div className="w-12 h-12 border-4 border-[var(--accent)] border-t-transparent rounded-full animate-spin" />
           </div>
         ) : (
-          <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-8 xl:grid-cols-4 md:grid-cols-2 lg:grid-cols-3">
             {certs.map((cert) => (
               <a key={cert.id} href={fromCorsUrl(cert.img)} target="_blank" rel="noopener noreferrer">
               <div

--- a/src/components/Contests.tsx
+++ b/src/components/Contests.tsx
@@ -59,7 +59,7 @@ export default function Contests() {
                 {contests.map((contest) => (
                   <div
                     key={contest.id}
-                    className="relative min-w-full sm:min-w-1/2 lg:min-w-1/4 transform transition-transform duration-300 hover:z-10 hover:scale-105 snap-start border-x border-dashed rounded-xl p-4 bg-[var(--accent)]/10"
+                    className="relative min-w-full sm:min-w-1/2 lg:min-w-1/3 xl:min-w-1/4 transform transition-transform duration-300 hover:z-10 hover:scale-105 snap-start border-x border-dashed rounded-xl p-4 bg-[var(--accent)]/10"
                     style={{ borderColor: 'var(--accent)', willChange: 'transform' }}
                   >
                     <a href={fromCorsUrl(contest.img)} target="_blank" rel="noopener noreferrer">

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,7 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import CachedImage from "./CachedImage";
-import { toCorsUrl } from "../utils/url";
+import { toCorsUrl, fromCorsUrl } from "../utils/url";
 
 interface Tag {
   id: number;
@@ -40,20 +40,19 @@ export default function Projects() {
             <div className="w-12 h-12 border-4 border-[var(--accent)] border-t-transparent rounded-full animate-spin" />
           </div>
         ) : (
-          <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2">
             {projects.map((project) => (
               <div
                 key={project.id}
-                className="relative overflow-hidden rounded-xl border-x border-dashed p-4 bg-[var(--accent)]/10"
+                className="relative overflow-hidden rounded-xl border-x border-dashed p-4 bg-[var(--accent)]/10 cursor-pointer"
+                onClick={() => window.open(fromCorsUrl(project.img), '_blank')}
                 style={{ borderColor: 'var(--accent)' }}
               >
-                <a href={project.url} target="_blank" rel="noopener noreferrer">
-                  <CachedImage
-                    src={project.img}
-                    alt={project.title}
-                    className="w-full h-1/2 object-cover rounded"
-                  />
-                </a>
+                <CachedImage
+                  src={project.img}
+                  alt={project.title}
+                  className="w-full aspect-square object-cover rounded"
+                />
                 <div className="mt-2 space-y-1">
                   <h3 className="text-xl font-semibold text-[var(--accent)]">
                     {project.title}
@@ -63,7 +62,7 @@ export default function Projects() {
                     {project.tags.map((tag) => (
                       <span
                         key={tag.id}
-                        className="text-xs px-2 py-1 rounded bg-[var(--accent)] text-[var(--bg)]"
+                        className="text-xs px-2 py-1 rounded-full bg-[var(--accent)] text-[var(--bg)]"
                       >
                         {tag.title}
                       </span>

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -40,7 +40,7 @@ export default function Projects() {
             <div className="w-12 h-12 border-4 border-[var(--accent)] border-t-transparent rounded-full animate-spin" />
           </div>
         ) : (
-          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4 ">
+          <div className="grid gap-8 sm:grid-cols-2 xl:grid-cols-4 md:grid-cols-3 lg:grid-cols-3 ">
             {projects.map((project) => (
               <div
                 key={project.id}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -1,0 +1,88 @@
+"use client";
+import { useEffect, useState } from "react";
+import CachedImage from "./CachedImage";
+import { toCorsUrl } from "../utils/url";
+
+interface Tag {
+  id: number;
+  title: string;
+}
+
+interface Project {
+  id: number;
+  title: string;
+  desc: string;
+  url: string;
+  img: string;
+  tags: Tag[];
+}
+
+export default function Projects() {
+  const [projects, setProjects] = useState<Project[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch("https://aoueesah.pythonanywhere.com/api/project/")
+      .then((res) => res.json())
+      .then((data: Project[]) =>
+        setProjects(data.map((p) => ({ ...p, img: toCorsUrl(p.img) })))
+      )
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  return (
+    <section id="projects" className="min-h-screen flex items-center justify-center fade-in-up">
+      <div className="container mx-auto px-4 space-y-8">
+        <h2 className="text-3xl font-bold text-center">Projects</h2>
+        {loading ? (
+          <div className="flex items-center justify-center w-20 h-20 mx-auto">
+            <div className="w-12 h-12 border-4 border-[var(--accent)] border-t-transparent rounded-full animate-spin" />
+          </div>
+        ) : (
+          <div className="grid gap-8 md:grid-cols-2 lg:grid-cols-3">
+            {projects.map((project) => (
+              <div
+                key={project.id}
+                className="relative overflow-hidden rounded-xl border-x border-dashed p-4 bg-[var(--accent)]/10"
+                style={{ borderColor: 'var(--accent)' }}
+              >
+                <a href={project.url} target="_blank" rel="noopener noreferrer">
+                  <CachedImage
+                    src={project.img}
+                    alt={project.title}
+                    className="w-full h-1/2 object-cover rounded"
+                  />
+                </a>
+                <div className="mt-2 space-y-1">
+                  <h3 className="text-xl font-semibold text-[var(--accent)]">
+                    {project.title}
+                  </h3>
+                  <p className="text-sm">{project.desc}</p>
+                  <div className="flex flex-wrap gap-2 mt-2">
+                    {project.tags.map((tag) => (
+                      <span
+                        key={tag.id}
+                        className="text-xs px-2 py-1 rounded bg-[var(--accent)] text-[var(--bg)]"
+                      >
+                        {tag.title}
+                      </span>
+                    ))}
+                  </div>
+                  <a
+                    href={project.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-block mt-2 text-[var(--accent)] underline"
+                  >
+                    View Source
+                  </a>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -40,18 +40,20 @@ export default function Projects() {
             <div className="w-12 h-12 border-4 border-[var(--accent)] border-t-transparent rounded-full animate-spin" />
           </div>
         ) : (
-          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3 lg:grid-rows-2">
+          <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-4 ">
             {projects.map((project) => (
               <div
                 key={project.id}
                 className="relative overflow-hidden rounded-xl border-x border-dashed p-4 bg-[var(--accent)]/10 cursor-pointer"
-                onClick={() => window.open(fromCorsUrl(project.img), '_blank')}
                 style={{ borderColor: 'var(--accent)' }}
               >
+
                 <CachedImage
                   src={project.img}
                   alt={project.title}
                   className="w-full aspect-square object-cover rounded"
+                  onClick={() => window.open(fromCorsUrl(project.img), '_blank')}
+
                 />
                 <div className="mt-2 space-y-1">
                   <h3 className="text-xl font-semibold text-[var(--accent)]">

--- a/src/components/TrainingCourses.tsx
+++ b/src/components/TrainingCourses.tsx
@@ -63,7 +63,7 @@ export default function TrainingCourses() {
                 {courses.map((course) => (
                   <div
                     key={course.id}
-                    className="relative min-w-full sm:min-w-1/2 lg:min-w-1/4 transform transition-transform duration-300 hover:z-10 hover:scale-105 snap-start border-x border-dashed rounded-xl p-4 bg-[var(--accent)]/10"
+                    className="relative min-w-full sm:min-w-1/2 lg:min-w-1/3 xl:min-w-1/4 transform transition-transform duration-300 hover:z-10 hover:scale-105 snap-start border-x border-dashed rounded-xl p-4 bg-[var(--accent)]/10"
                     style={{ borderColor: 'var(--accent)', willChange: 'transform'}}
                   >
                     <a href={fromCorsUrl(course.img)} target="_blank" rel="noopener noreferrer">


### PR DESCRIPTION
## Summary
- implement new `Projects` component that fetches projects from the provided API
- render projects on the home page after the contests section
- include loading state and tag styling

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872b0a9cd248331b1bec1b1c1712949