### PR TITLE
Add responsive header navigation

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -69,7 +69,7 @@ export default function Hero() {
   }, []);
   if(loading)
   {
-    return (<section className="h-screen flex items-center justify-center fade-in-up ">{loading && (
+    return (<section id="home" className="h-screen flex items-center justify-center fade-in-up ">{loading && (
       <div className="flex items-center justify-center w-80 h-80">
         <div className="w-12 h-12 border-4 border-[var(--accent)] border-t-transparent rounded-full animate-spin" />
       </div>
@@ -78,7 +78,7 @@ export default function Hero() {
 
   return (
     
-    <section className="h-screen flex items-center justify-center fade-in-up ">
+    <section id="home" className="h-screen flex items-center justify-center fade-in-up ">
       <div className="container mx-auto flex flex-col md:flex-row items-center gap-8 md:gap-16 md:px-50">
         
         {info && (

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState, ReactNode } from "react";
 
 export default function ThemeProvider({ children }: { children: ReactNode }) {
   const [theme, setTheme] = useState<'light' | 'dark'>('light');
+  const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
     const stored = localStorage.getItem('theme') as 'light' | 'dark' | null;
@@ -19,17 +20,69 @@ export default function ThemeProvider({ children }: { children: ReactNode }) {
     localStorage.setItem('theme', theme);
   }, [theme]);
 
+  const links = [
+    { id: 'home', label: 'Home' },
+    { id: 'about', label: 'About' },
+    { id: 'skills', label: 'Skills' },
+    { id: 'experience', label: 'Experience' },
+    { id: 'certificates', label: 'Certificates' },
+    { id: 'training', label: 'Training' },
+    { id: 'contests', label: 'Contests' },
+    { id: 'projects', label: 'Projects' },
+  ];
+
+  const toggleTheme = () => setTheme(theme === 'light' ? 'dark' : 'light');
+
   return (
     <>
-      <header className="fixed top-0 w-full p-4 flex justify-end z-10">
-        <button
-          onClick={() => setTheme(theme === 'light' ? 'dark' : 'light')}
-          className="px-3 py-1 rounded bg-[var(--accent)] text-[var(--bg)]"
-        >
-          {theme === 'light' ? 'Dark' : 'Light'} Mode
-        </button>
+      <header className="fixed top-0 w-full p-4 flex justify-between items-center bg-[var(--bg)] z-10 shadow">
+        <a href="#home" className="font-bold text-[var(--accent)]">Portfolio</a>
+        <nav className="hidden md:flex space-x-4 items-center">
+          {links.map((l) => (
+            <a key={l.id} href={`#${l.id}`} className="hover:text-[var(--accent)]">
+              {l.label}
+            </a>
+          ))}
+          <button
+            onClick={toggleTheme}
+            className="px-3 py-1 rounded bg-[var(--accent)] text-[var(--bg)] ml-2"
+          >
+            {theme === 'light' ? 'Dark' : 'Light'} Mode
+          </button>
+        </nav>
+        <div className="md:hidden flex items-center">
+          <button
+            onClick={() => setMenuOpen(!menuOpen)}
+            className="px-2 py-1 border rounded"
+          >
+            {menuOpen ? 'Close' : 'Menu'}
+          </button>
+        </div>
       </header>
-      <main >{children}</main>
+      {menuOpen && (
+        <nav className="md:hidden fixed top-16 right-4 bg-[var(--bg)] border rounded shadow p-4 space-y-2 z-10">
+          {links.map((l) => (
+            <a
+              key={l.id}
+              href={`#${l.id}`}
+              className="block hover:text-[var(--accent)]"
+              onClick={() => setMenuOpen(false)}
+            >
+              {l.label}
+            </a>
+          ))}
+          <button
+            onClick={() => {
+              toggleTheme();
+              setMenuOpen(false);
+            }}
+            className="w-full px-3 py-1 rounded bg-[var(--accent)] text-[var(--bg)]"
+          >
+            {theme === 'light' ? 'Dark' : 'Light'} Mode
+          </button>
+        </nav>
+      )}
+      <main className="pt-20">{children}</main>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- create a responsive navigation menu in `theme-provider`
- add id `home` to Hero section for navigation anchors

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6873b4d89f308331a4e2b9c7f921d63c