### PR TITLE
Add local API caching

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { cachedFetch } from "../utils/cachedFetch";
 
 interface Language {
   id: number;
@@ -12,9 +13,8 @@ export default function About() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("https://aoueesah.pythonanywhere.com/api/lang/")
-      .then((res) => res.json())
-      .then((data: Language[]) => setLangs(data))
+    cachedFetch<Language[]>("https://aoueesah.pythonanywhere.com/api/lang/", 86400)
+      .then((data) => setLangs(data))
       .catch(() => {})
       .finally(() => setLoading(false));
   }, []);

--- a/src/components/Certificates.tsx
+++ b/src/components/Certificates.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import CachedImage from "./CachedImage";
 import { toCorsUrl, fromCorsUrl } from "../utils/url";
+import { cachedFetch } from "../utils/cachedFetch";
 
 interface Certificate {
   id: number;
@@ -19,9 +20,11 @@ export default function Certificates() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("https://aoueesah.pythonanywhere.com/api/scintific-certificate/")
-      .then((res) => res.json())
-      .then((data: Certificate[]) =>
+    cachedFetch<Certificate[]>(
+      "https://aoueesah.pythonanywhere.com/api/scintific-certificate/",
+      86400
+    )
+      .then((data) =>
         setCerts(data.map((c) => ({ ...c, img: toCorsUrl(c.img) })))
       )
       .catch(() => {})

--- a/src/components/Contests.tsx
+++ b/src/components/Contests.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import CachedImage from "./CachedImage";
 import { toCorsUrl, fromCorsUrl } from "../utils/url";
+import { cachedFetch } from "../utils/cachedFetch";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
 
 interface Contest {
@@ -18,9 +19,8 @@ export default function Contests() {
   const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    fetch("https://aoueesah.pythonanywhere.com/api/contest/")
-      .then((res) => res.json())
-      .then((data: Contest[]) => {
+    cachedFetch<Contest[]>("https://aoueesah.pythonanywhere.com/api/contest/", 86400)
+      .then((data) => {
         const sorted = data.sort(
           (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
         );

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,5 +1,6 @@
 "use client";
 import { useEffect, useState } from "react";
+import { cachedFetch } from "../utils/cachedFetch";
 
 interface Experience {
   id: number;
@@ -32,9 +33,8 @@ export default function Experience() {
   const [loading, setLoading] = useState(true)
 
   useEffect(() => {
-    fetch("https://aoueesah.pythonanywhere.com/api/experience/")
-      .then((res) => res.json())
-      .then((data: Experience[]) => {
+    cachedFetch<Experience[]>("https://aoueesah.pythonanywhere.com/api/experience/", 86400)
+      .then((data) => {
         const sorted = data.sort(
           (a, b) => new Date(b.endDate).getTime() - new Date(a.endDate).getTime()
         );

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import CachedImage from "./CachedImage";
 import { toCorsUrl } from "../utils/url";
+import { cachedFetch } from "../utils/cachedFetch";
 import { PhoneIcon, EnvelopeIcon } from "@heroicons/react/24/outline";
 
 interface Info {
@@ -34,11 +35,10 @@ export default function Hero() {
 
   useEffect(() => {
     Promise.all([
-      fetch("https://aoueesah.pythonanywhere.com/api/info/").then((res) =>
-        res.json()
-      ),
-      fetch("https://aoueesah.pythonanywhere.com/api/social-network/").then((res) =>
-        res.json()
+      cachedFetch<Info[]>("https://aoueesah.pythonanywhere.com/api/info/", 86400),
+      cachedFetch<Social[]>(
+        "https://aoueesah.pythonanywhere.com/api/social-network/",
+        86400
       ),
     ])
       .then(([infoData, socialData]: [Info[], Social[]]) => {

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useState } from "react";
 import CachedImage from "./CachedImage";
 import { toCorsUrl, fromCorsUrl } from "../utils/url";
+import { cachedFetch } from "../utils/cachedFetch";
 
 interface Tag {
   id: number;
@@ -22,9 +23,8 @@ export default function Projects() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("https://aoueesah.pythonanywhere.com/api/project/")
-      .then((res) => res.json())
-      .then((data: Project[]) =>
+    cachedFetch<Project[]>("https://aoueesah.pythonanywhere.com/api/project/", 86400)
+      .then((data) =>
         setProjects(data.map((p) => ({ ...p, img: toCorsUrl(p.img) })))
       )
       .catch(() => {})

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -4,6 +4,7 @@ import {
   CircularProgressbar,
   buildStyles
 } from 'react-circular-progressbar';
+import { cachedFetch } from "../utils/cachedFetch";
 import 'react-circular-progressbar/dist/styles.css';
 
 
@@ -23,9 +24,8 @@ export default function Skills() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch("https://aoueesah.pythonanywhere.com/api/skill/")
-      .then((res) => res.json())
-      .then((data: Skill[]) => setSkills(data))
+    cachedFetch<Skill[]>("https://aoueesah.pythonanywhere.com/api/skill/", 86400)
+      .then((data) => setSkills(data))
       .catch(() => {})
       .finally(() => setLoading(false));
   }, []);

--- a/src/components/TrainingCourses.tsx
+++ b/src/components/TrainingCourses.tsx
@@ -2,6 +2,7 @@
 import { useEffect, useRef, useState } from "react";
 import CachedImage from "./CachedImage";
 import { toCorsUrl, fromCorsUrl } from "../utils/url";
+import { cachedFetch } from "../utils/cachedFetch";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
 
 interface TrainingCourse {
@@ -19,9 +20,8 @@ export default function TrainingCourses() {
   const listRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    fetch("https://aoueesah.pythonanywhere.com/api/tranning-course/")
-      .then((res) => res.json())
-      .then((data: TrainingCourse[]) => {
+    cachedFetch<TrainingCourse[]>("https://aoueesah.pythonanywhere.com/api/tranning-course/", 86400)
+      .then((data) => {
         const sorted = data.sort(
           (a, b) => new Date(b.date).getTime() - new Date(a.date).getTime()
         );

--- a/src/utils/cachedFetch.ts
+++ b/src/utils/cachedFetch.ts
@@ -1,0 +1,30 @@
+export async function cachedFetch<T>(url: string, ttlSeconds = 3600): Promise<T> {
+  const key = `cache:${url}`;
+
+  if (typeof localStorage !== 'undefined') {
+    try {
+      const cached = localStorage.getItem(key);
+      if (cached) {
+        const { timestamp, data } = JSON.parse(cached);
+        if (Date.now() - timestamp < ttlSeconds * 1000) {
+          return data as T;
+        }
+      }
+    } catch {
+      // ignore malformed cache
+    }
+  }
+
+  const res = await fetch(url);
+  const data = await res.json();
+
+  if (typeof localStorage !== 'undefined') {
+    try {
+      localStorage.setItem(key, JSON.stringify({ timestamp: Date.now(), data }));
+    } catch {
+      // ignore quota errors
+    }
+  }
+
+  return data as T;
+}


### PR DESCRIPTION
## Summary
- add cachedFetch util to memoize backend requests
- use cachedFetch in data-fetching components to reduce API traffic

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6873ca83390c8331964738c26fb3cd69