### PR TITLE
Modernize color palette

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,12 +5,13 @@
 @tailwind utilities;
 
 :root {
-  --bg-light: #eeeeee;
-  --text-light: #171717;
-  --bg-dark: #0a0a0a;
-  --text-dark: #ededed;
-  --accent-light: #3b82f6;
-  --accent-dark: #84cc16;
+  /* Modern color palette */
+  --bg-light: #f3f4f6;
+  --text-light: #1f2937;
+  --bg-dark: #111827;
+  --text-dark: #f3f4f6;
+  --accent-light: #6366f1;
+  --accent-dark: #ec4899;
 }
 
 html.light {

--- a/tailwind.config.mjs
+++ b/tailwind.config.mjs
@@ -15,8 +15,8 @@ export default {
           dark: '#0ea5e9',
         },
         accent: {
-          DEFAULT: '#84cc16',
-          dark: '#4ade80',
+          DEFAULT: '#6366f1',
+          dark: '#ec4899',
         }
       }
     }


### PR DESCRIPTION
## Summary
- modernize default light/dark colors in globals.css
- update accent shades in Tailwind config

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6874d8a7104883318b04d9527b6b2e6d