### PR TITLE
Fix fade-in animations

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,4 @@
 'use client'
-import { useEffect } from 'react'
 import Hero from '@/components/Hero'
 import About from '@/components/About'
 import Skills from '@/components/Skills'
@@ -10,18 +9,6 @@ import Projects from '@/components/Projects'
 import Experience from '@/components/Experience'
 
 export default function Home() {
-  useEffect(() => {
-    const elements = document.querySelectorAll('.fade-in-up')
-    const observer = new IntersectionObserver(entries => {
-      entries.forEach(entry => {
-        if (entry.isIntersecting) {
-          entry.target.classList.add('show')
-        }
-      })
-    }, { threshold: 0.1 })
-    elements.forEach(el => observer.observe(el))
-    return () => observer.disconnect()
-  }, [])
 
   return (
     <div >

--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { cachedFetch } from "../utils/cachedFetch";
+import useFadeIn from "@/utils/useFadeIn";
 
 interface Language {
   id: number;
@@ -11,6 +12,7 @@ interface Language {
 export default function About() {
   const [langs, setLangs] = useState<Language[]>([]);
   const [loading, setLoading] = useState(true);
+  const sectionRef = useFadeIn<HTMLElement>();
 
   useEffect(() => {
     cachedFetch<Language[]>("https://aoueesah.pythonanywhere.com/api/lang/",)
@@ -20,7 +22,7 @@ export default function About() {
   }, []);
 
   return (
-    <section id="about" className="min-h-screen flex items-center justify-center fade-in-up">
+    <section ref={sectionRef} id="about" className="min-h-screen flex items-center justify-center fade-in-up">
       <div className="container mx-auto px-4 space-y-8">
         <h2 className="text-3xl font-bold text-center">About me</h2>
         <div className="grid gap-8 md:grid-cols-2">

--- a/src/components/Certificates.tsx
+++ b/src/components/Certificates.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import CachedImage from "./CachedImage";
 import { toCorsUrl, fromCorsUrl } from "../utils/url";
 import { cachedFetch } from "../utils/cachedFetch";
+import useFadeIn from "@/utils/useFadeIn";
 
 interface Certificate {
   id: number;
@@ -18,6 +19,7 @@ interface Certificate {
 export default function Certificates() {
   const [certs, setCerts] = useState<Certificate[]>([]);
   const [loading, setLoading] = useState(true);
+  const sectionRef = useFadeIn<HTMLElement>();
 
   useEffect(() => {
     cachedFetch<Certificate[]>(
@@ -31,7 +33,7 @@ export default function Certificates() {
   }, []);
 
   return (
-    <section id="certificates" className="min-h-screen flex items-center justify-center ">
+    <section ref={sectionRef} id="certificates" className="min-h-screen flex items-center justify-center fade-in-up">
       <div className=" container mx-auto px-4 text-center space-y-8">
         <h2 className="text-3xl font-bold">Scientific Certificates</h2>
         {loading ? (

--- a/src/components/Contests.tsx
+++ b/src/components/Contests.tsx
@@ -4,6 +4,7 @@ import CachedImage from "./CachedImage";
 import { toCorsUrl, fromCorsUrl } from "../utils/url";
 import { cachedFetch } from "../utils/cachedFetch";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
+import useFadeIn from "@/utils/useFadeIn";
 
 interface Contest {
   id: number;
@@ -17,6 +18,7 @@ export default function Contests() {
   const [contests, setContests] = useState<Contest[]>([]);
   const [loading, setLoading] = useState(true);
   const listRef = useRef<HTMLDivElement>(null);
+  const sectionRef = useFadeIn<HTMLElement>();
 
   useEffect(() => {
     cachedFetch<Contest[]>("https://aoueesah.pythonanywhere.com/api/contest/",)
@@ -39,7 +41,7 @@ export default function Contests() {
   };
 
   return (
-    <section id="contests" className="min-h-screen flex items-center justify-center fade-in-up">
+    <section ref={sectionRef} id="contests" className="min-h-screen flex items-center justify-center fade-in-up">
       <div className="container mx-auto space-y-8 overflow-visible">
         <h2 className="text-3xl font-bold text-center">Contests</h2>
         {loading ? (

--- a/src/components/Experience.tsx
+++ b/src/components/Experience.tsx
@@ -1,6 +1,7 @@
 "use client";
 import { useEffect, useState } from "react";
 import { cachedFetch } from "../utils/cachedFetch";
+import useFadeIn from "@/utils/useFadeIn";
 
 interface Experience {
   id: number;
@@ -31,6 +32,7 @@ function formatDuration(start: string, end: string) {
 export default function Experience() {
   const [experiences, setExperiences] = useState<Experience[]>([])
   const [loading, setLoading] = useState(true)
+  const sectionRef = useFadeIn<HTMLElement>()
 
   useEffect(() => {
     cachedFetch<Experience[]>("https://aoueesah.pythonanywhere.com/api/experience/", )
@@ -45,7 +47,7 @@ export default function Experience() {
   }, []);
 
   return (
-    <section id="experience" className="min-h-screen flex items-center justify-center fade-in-up">
+    <section ref={sectionRef} id="experience" className="min-h-screen flex items-center justify-center fade-in-up">
       <div className="container mx-auto px-4 space-y-8">
         <h2 className="text-3xl font-bold text-center">Experience</h2>
         {loading ? (

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -4,6 +4,7 @@ import CachedImage from "./CachedImage";
 import { toCorsUrl } from "../utils/url";
 import { cachedFetch } from "../utils/cachedFetch";
 import { PhoneIcon, EnvelopeIcon } from "@heroicons/react/24/outline";
+import useFadeIn from "@/utils/useFadeIn";
 
 interface Info {
   id: number;
@@ -32,6 +33,7 @@ export default function Hero() {
   const [socials, setSocials] = useState<Social[]>([]);
   const [loading, setLoading] = useState(true);
   const [titleIndex, setTitleIndex] = useState(0);
+  const sectionRef = useFadeIn<HTMLElement>();
 
   useEffect(() => {
     Promise.all([
@@ -69,7 +71,7 @@ export default function Hero() {
   }, []);
   if(loading)
   {
-    return (<section id="home" className="h-screen flex items-center justify-center fade-in-up ">{loading && (
+    return (<section ref={sectionRef} id="home" className="h-screen flex items-center justify-center fade-in-up ">{loading && (
       <div className="flex items-center justify-center w-80 h-80">
         <div className="w-12 h-12 border-4 border-[var(--accent)] border-t-transparent rounded-full animate-spin" />
       </div>
@@ -78,7 +80,7 @@ export default function Hero() {
 
   return (
     
-    <section id="home" className="h-screen flex items-center justify-center fade-in-up ">
+    <section ref={sectionRef} id="home" className="h-screen flex items-center justify-center fade-in-up ">
       <div className="container mx-auto flex flex-col md:flex-row items-center gap-8 md:gap-16 justify-evenly">
         
         {info && (

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import CachedImage from "./CachedImage";
 import { toCorsUrl, fromCorsUrl } from "../utils/url";
 import { cachedFetch } from "../utils/cachedFetch";
+import useFadeIn from "@/utils/useFadeIn";
 
 interface Tag {
   id: number;
@@ -21,6 +22,7 @@ interface Project {
 export default function Projects() {
   const [projects, setProjects] = useState<Project[]>([]);
   const [loading, setLoading] = useState(true);
+  const sectionRef = useFadeIn<HTMLElement>();
 
   useEffect(() => {
     cachedFetch<Project[]>("https://aoueesah.pythonanywhere.com/api/project/", )
@@ -32,7 +34,7 @@ export default function Projects() {
   }, []);
 
   return (
-    <section id="projects" className="min-h-screen flex items-center justify-center fade-in-up">
+    <section ref={sectionRef} id="projects" className="min-h-screen flex items-center justify-center fade-in-up">
       <div className="container mx-auto px-4 space-y-8">
         <h2 className="text-3xl font-bold text-center">Projects</h2>
         {loading ? (

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -5,6 +5,7 @@ import {
   buildStyles
 } from 'react-circular-progressbar';
 import { cachedFetch } from "../utils/cachedFetch";
+import useFadeIn from "@/utils/useFadeIn";
 import 'react-circular-progressbar/dist/styles.css';
 
 
@@ -22,6 +23,7 @@ interface Skill {
 export default function Skills() {
   const [skills, setSkills] = useState<Skill[]>([]);
   const [loading, setLoading] = useState(true);
+  const sectionRef = useFadeIn<HTMLElement>();
 
   useEffect(() => {
     cachedFetch<Skill[]>("https://aoueesah.pythonanywhere.com/api/skill/", )
@@ -38,7 +40,7 @@ export default function Skills() {
   }, {});
 
   return (
-    <section id="skills" className="min-h-screen flex items-center justify-center fade-in-up">
+    <section ref={sectionRef} id="skills" className="min-h-screen flex items-center justify-center fade-in-up">
       <div className="container mx-auto px-4 text-center space-y-4">
         <h2 className="text-3xl font-bold">Skills</h2>
         {loading ? (

--- a/src/components/TrainingCourses.tsx
+++ b/src/components/TrainingCourses.tsx
@@ -4,6 +4,7 @@ import CachedImage from "./CachedImage";
 import { toCorsUrl, fromCorsUrl } from "../utils/url";
 import { cachedFetch } from "../utils/cachedFetch";
 import { ChevronLeftIcon, ChevronRightIcon } from "@heroicons/react/24/outline";
+import useFadeIn from "@/utils/useFadeIn";
 
 interface TrainingCourse {
   id: number;
@@ -18,6 +19,7 @@ export default function TrainingCourses() {
   const [courses, setCourses] = useState<TrainingCourse[]>([]);
   const [loading, setLoading] = useState(true);
   const listRef = useRef<HTMLDivElement>(null);
+  const sectionRef = useFadeIn<HTMLElement>();
 
   useEffect(() => {
     cachedFetch<TrainingCourse[]>("https://aoueesah.pythonanywhere.com/api/tranning-course/", )
@@ -42,7 +44,7 @@ export default function TrainingCourses() {
   };
 
   return (
-    <section id="training" className="min-h-screen flex flex-col overflow-visible items-center justify-center fade-in-up">
+    <section ref={sectionRef} id="training" className="min-h-screen flex flex-col overflow-visible items-center justify-center fade-in-up">
       <div className="container mx-auto space-y-8 overflow-visible">
         <h2 className="text-3xl font-bold text-center">Training Courses</h2>
         {loading ? (

--- a/src/utils/useFadeIn.ts
+++ b/src/utils/useFadeIn.ts
@@ -1,0 +1,25 @@
+import { useEffect, useRef } from 'react'
+
+export default function useFadeIn<T extends HTMLElement>() {
+  const ref = useRef<T>(null)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node) return
+    const observer = new IntersectionObserver(
+      entries => {
+        entries.forEach(entry => {
+          if (entry.isIntersecting) {
+            entry.target.classList.add('show')
+            observer.unobserve(entry.target)
+          }
+        })
+      },
+      { threshold: 0.1 }
+    )
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [])
+
+  return ref
+}

--- a/src/utils/useFadeIn.ts
+++ b/src/utils/useFadeIn.ts
@@ -11,7 +11,8 @@ export default function useFadeIn<T extends HTMLElement>() {
         entries.forEach(entry => {
           if (entry.isIntersecting) {
             entry.target.classList.add('show')
-            observer.unobserve(entry.target)
+          } else {
+            entry.target.classList.remove('show')
           }
         })
       },


### PR DESCRIPTION
## Summary
- add custom `useFadeIn` hook to manage IntersectionObserver
- attach fade-in hook to each section component
- remove global IntersectionObserver logic

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68755463db148331ac639b35a7b60771